### PR TITLE
Coordinates accept space separated <6 values

### DIFF
--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -182,8 +182,9 @@ class _AngleParser(object):
         def p_hms(p):
             '''
             hms : sign UINT HOUR
-                | sign UINT HOUR UINT
+                | sign UINT HOUR ufloat
                 | sign UINT HOUR UINT MINUTE
+                | sign UINT HOUR UFLOAT MINUTE
                 | sign UINT HOUR UINT MINUTE ufloat
                 | sign UINT HOUR UINT MINUTE ufloat SECOND
                 | generic HOUR
@@ -200,8 +201,9 @@ class _AngleParser(object):
         def p_dms(p):
             '''
             dms : sign UINT DEGREE
-                | sign UINT DEGREE UINT
+                | sign UINT DEGREE ufloat
                 | sign UINT DEGREE UINT MINUTE
+                | sign UINT DEGREE UFLOAT MINUTE
                 | sign UINT DEGREE UINT MINUTE ufloat
                 | sign UINT DEGREE UINT MINUTE ufloat SECOND
                 | generic DEGREE

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -149,7 +149,7 @@ class _AngleParser(object):
 
         def p_colon(p):
             '''
-            colon : sign UINT COLON UINT
+            colon : sign UINT COLON ufloat
                   | sign UINT COLON UINT COLON ufloat
             '''
             if len(p) == 5:
@@ -159,7 +159,7 @@ class _AngleParser(object):
 
         def p_spaced(p):
             '''
-            spaced : sign UINT UINT
+            spaced : sign UINT ufloat
                    | sign UINT UINT ufloat
             '''
             if len(p) == 4:
@@ -361,7 +361,7 @@ def degrees_to_dms(d):
     return np.floor(sign * d), sign * np.floor(m), sign * s
 
 
-def dms_to_degrees(d, m, s):
+def dms_to_degrees(d, m, s=0):
     """
     Convert degrees, arcminute, arcsecond to a float degrees value.
     """
@@ -374,10 +374,12 @@ def dms_to_degrees(d, m, s):
 
     # TODO: This will fail if d or m have values after the decimal
     # place
-
     try:
         d = np.floor(np.abs(np.asarray(d)))
-        m = np.floor(np.abs(np.asarray(m)))
+        if np.isscalar(s) and s == 0:
+            m = np.abs(m)
+        else:
+            m = np.floor(np.abs(np.asarray(m)))
         s = np.abs(s)
     except ValueError:
         raise ValueError(format_exception(
@@ -387,7 +389,7 @@ def dms_to_degrees(d, m, s):
     return sign * (d + m / 60. + s / 3600.)
 
 
-def hms_to_hours(h, m, s):
+def hms_to_hours(h, m, s=0):
     """
     Convert hour, minute, second to a float hour value.
     """
@@ -402,7 +404,10 @@ def hms_to_hours(h, m, s):
 
     try:
         h = np.floor(np.abs(h))
-        m = np.floor(np.abs(m))
+        if np.isscalar(s) and s == 0:
+            m = np.abs(m)
+        else:
+            m = np.floor(np.abs(np.asarray(m)))
         s = np.abs(s)
     except ValueError:
         raise ValueError(format_exception(

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -374,14 +374,12 @@ def dms_to_degrees(d, m, s=0):
     # determine sign
     sign = np.copysign(1.0, d)
 
-    # TODO: This will fail if d or m have values after the decimal
-    # place
     try:
-        d = np.floor(np.abs(np.asarray(d)))
+        d = np.floor(np.abs(d))
         if np.isscalar(s) and s == 0:
             m = np.abs(m)
         else:
-            m = np.floor(np.abs(np.asarray(m)))
+            m = np.floor(np.abs(m))
         s = np.abs(s)
     except ValueError:
         raise ValueError(format_exception(
@@ -401,15 +399,12 @@ def hms_to_hours(h, m, s=0):
     # determine sign
     sign = np.copysign(1.0, h)
 
-    # TODO: This will fail if d or m have values after the decimal
-    # place
-
     try:
         h = np.floor(np.abs(h))
         if np.isscalar(s) and s == 0:
             m = np.abs(m)
         else:
-            m = np.floor(np.abs(np.asarray(m)))
+            m = np.floor(np.abs(m))
         s = np.abs(s)
     except ValueError:
         raise ValueError(format_exception(

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -153,7 +153,7 @@ class _AngleParser(object):
                   | sign UINT COLON UINT COLON ufloat
             '''
             if len(p) == 5:
-                p[0] = (p[1] * p[2], p[4], 0.0)
+                p[0] = (p[1] * p[2], p[4])
             elif len(p) == 7:
                 p[0] = (p[1] * p[2], p[4], p[6])
 
@@ -163,7 +163,7 @@ class _AngleParser(object):
                    | sign UINT UINT ufloat
             '''
             if len(p) == 4:
-                p[0] = (p[1] * p[2], p[3], 0.0)
+                p[0] = (p[1] * p[2], p[3])
             elif len(p) == 5:
                 p[0] = (p[1] * p[2], p[3], p[4])
 
@@ -194,7 +194,7 @@ class _AngleParser(object):
             elif len(p) == 4:
                 p[0] = (p[1] * p[2], u.hourangle)
             elif len(p) in (5, 6):
-                p[0] = ((p[1] * p[2], p[4], 0.0), u.hourangle)
+                p[0] = ((p[1] * p[2], p[4]), u.hourangle)
             elif len(p) in (7, 8):
                 p[0] = ((p[1] * p[2], p[4], p[6]), u.hourangle)
 
@@ -213,7 +213,7 @@ class _AngleParser(object):
             elif len(p) == 4:
                 p[0] = (p[1] * p[2], u.degree)
             elif len(p) in (5, 6):
-                p[0] = ((p[1] * p[2], p[4], 0.0), u.degree)
+                p[0] = ((p[1] * p[2], p[4]), u.degree)
             elif len(p) in (7, 8):
                 p[0] = ((p[1] * p[2], p[4], p[6]), u.degree)
 
@@ -299,6 +299,8 @@ def _check_second_range(sec):
     """
     if np.any(sec == 60.):
         warn(IllegalSecondWarning(sec, 'Treating as 0 sec, +1 min'))
+    elif sec is None:
+        pass
     elif np.any(sec < -60.) or np.any(sec > 60.):
         # "Error: seconds not in range [-60,60) ({0}).".format(sec))
         raise IllegalSecondError(sec)
@@ -363,7 +365,7 @@ def degrees_to_dms(d):
     return np.floor(sign * d), sign * np.floor(m), sign * s
 
 
-def dms_to_degrees(d, m, s=0):
+def dms_to_degrees(d, m, s=None):
     """
     Convert degrees, arcminute, arcsecond to a float degrees value.
     """
@@ -376,11 +378,12 @@ def dms_to_degrees(d, m, s=0):
 
     try:
         d = np.floor(np.abs(d))
-        if np.isscalar(s) and s == 0:
+        if s is None:
             m = np.abs(m)
+            s = 0
         else:
             m = np.floor(np.abs(m))
-        s = np.abs(s)
+            s = np.abs(s)
     except ValueError:
         raise ValueError(format_exception(
             "{func}: dms values ({1[0]},{2[1]},{3[2]}) could not be "
@@ -389,7 +392,7 @@ def dms_to_degrees(d, m, s=0):
     return sign * (d + m / 60. + s / 3600.)
 
 
-def hms_to_hours(h, m, s=0):
+def hms_to_hours(h, m, s=None):
     """
     Convert hour, minute, second to a float hour value.
     """
@@ -401,11 +404,12 @@ def hms_to_hours(h, m, s=0):
 
     try:
         h = np.floor(np.abs(h))
-        if np.isscalar(s) and s == 0:
+        if s is None:
             m = np.abs(m)
+            s = 0
         else:
             m = np.floor(np.abs(m))
-        s = np.abs(s)
+            s = np.abs(s)
     except ValueError:
         raise ValueError(format_exception(
             "{func}: HMS values ({1[0]},{2[1]},{3[2]}) could not be "

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -137,13 +137,12 @@ class Angle(u.Quantity):
     @staticmethod
     def _tuple_to_float(angle, unit):
         """
-        Converts an angle represented as a 3-tuple into a floating
+        Converts an angle represented as a 3-tuple or 2-tuple into a floating
         point number in the given unit.
         """
         if isinstance(angle, tuple):
             # TODO: Numpy array of tuples?
             if unit is u.hourangle:
-                util.check_hms_ranges(*angle)
                 angle = util.hms_to_hours(*angle)
             elif unit is u.degree:
                 angle = util.dms_to_degrees(*angle)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -19,7 +19,8 @@ from .representation import (BaseRepresentation, SphericalRepresentation,
 
 __all__ = ['SkyCoord']
 
-PMRE = re.compile('(\+|\-)')
+PMRE = re.compile(r'(\+|\-)')
+JPMRE = re.compile(r'J([0-9]{6}\.?[0-9]{0,2})([\+\-][0-9]{6}\.?[0-9]{0,2})\s*$')
 
 
 # Define a convenience mapping.  This is used like a module constants
@@ -922,6 +923,15 @@ def _parse_coordinate_arg(coords, frame, units):
                 elif len(coord1) > 2:
                     coord = PMRE.split(coord)
                     coord = (coord[0], ' '.join(coord[1:]))
+                elif len(coord1) == 1:
+                        try:
+                            coord = JPMRE.match(coord).groups()
+                            coord = ('{0} {1} {2}'.
+                                     format(coord[0][0:2], coord[0][2:4], coord[0][4:]),
+                                     '{0} {1} {2}'.
+                                     format(coord[1][0:3], coord[1][3:5], coord[1][5:]))
+                        except:
+                            coord = coord1
                 else:
                     coord = coord1
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 import collections
 
 import numpy as np
+import re
 
 from ..utils.compat.misc import override__dir__
 from ..extern import six
@@ -915,8 +916,12 @@ def _parse_coordinate_arg(coords, frame, units):
             if isinstance(coord, six.string_types):
                 coord1 = coord.split()
                 if len(coord1) == 6:
-                    coord1 = (' '.join(coord1[:3]), ' '.join(coord1[3:]))
-                coord = coord1
+                    coord = (' '.join(coord1[:3]), ' '.join(coord1[3:]))
+                elif len(coord1) > 2:
+                    coord = re.split('(\+|\-)', coord)
+                    coord = (coord[0], ' '.join(coord[1:]))
+                else:
+                    coord = coord1
 
             vals.append(coord)  # This assumes coord is a sequence at this point
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -19,6 +19,8 @@ from .representation import (BaseRepresentation, SphericalRepresentation,
 
 __all__ = ['SkyCoord']
 
+PMRE = re.compile('(\+|\-)')
+
 
 # Define a convenience mapping.  This is used like a module constants
 # but is actually dynamically evaluated.
@@ -918,7 +920,7 @@ def _parse_coordinate_arg(coords, frame, units):
                 if len(coord1) == 6:
                     coord = (' '.join(coord1[:3]), ' '.join(coord1[3:]))
                 elif len(coord1) > 2:
-                    coord = re.split('(\+|\-)', coord)
+                    coord = PMRE.split(coord)
                     coord = (coord[0], ' '.join(coord[1:]))
                 else:
                     coord = coord1

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -142,6 +142,11 @@ def test_coord_init_string():
     assert allclose(sc3.ra, Angle(120 * u.deg))
     assert allclose(sc3.dec, Angle(-5.01 * u.deg))
 
+    sc4 = SkyCoord('J080000.0-050036.0', unit=(u.hour, u.deg), frame='icrs')
+    assert isinstance(sc4, SkyCoord)
+    assert allclose(sc4.ra, Angle(120 * u.deg))
+    assert allclose(sc4.dec, Angle(-5.01 * u.deg))
+
 
 def test_coord_init_unit():
     """

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -147,6 +147,11 @@ def test_coord_init_string():
     assert allclose(sc4.ra, Angle(120 * u.deg))
     assert allclose(sc4.dec, Angle(-5.01 * u.deg))
 
+    sc5 = SkyCoord('8h 00.6m -5d 00.6m', unit=(u.hour, u.deg), frame='icrs')
+    assert isinstance(sc5, SkyCoord)
+    assert allclose(sc5.ra, Angle(120.15 * u.deg))
+    assert allclose(sc5.dec, Angle(-5.01 * u.deg))
+
 
 def test_coord_init_unit():
     """

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -132,9 +132,10 @@ def test_coord_init_string():
     assert allclose(sc1.ra, Angle(120 * u.deg))
     assert allclose(sc1.dec, Angle(5 * u.deg))
 
-    with pytest.raises(ValueError) as err:
-        SkyCoord('8 00 -5 00 00.0', unit=(u.hour, u.deg), frame='icrs')
-    assert 'coordinates have 5 values but spherical representation only accepts 3' in str(err)
+    sc2 = SkyCoord('8 00 -5 00 00.0', unit=(u.hour, u.deg), frame='icrs')
+    assert isinstance(sc2, SkyCoord)
+    assert allclose(sc2.ra, Angle(120 * u.deg))
+    assert allclose(sc2.dec, Angle(-5 * u.deg))
 
 
 def test_coord_init_unit():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -137,6 +137,11 @@ def test_coord_init_string():
     assert allclose(sc2.ra, Angle(120 * u.deg))
     assert allclose(sc2.dec, Angle(-5 * u.deg))
 
+    sc3 = SkyCoord('8 00 -5 00.6', unit=(u.hour, u.deg), frame='icrs')
+    assert isinstance(sc3, SkyCoord)
+    assert allclose(sc3.ra, Angle(120 * u.deg))
+    assert allclose(sc3.dec, Angle(-5.01 * u.deg))
+
 
 def test_coord_init_unit():
     """


### PR DESCRIPTION
This PR adds back the support for space separated sky coordinate values using the sign as separator when <6 values are given. This was once supported, and I couldn't find whether it was deliberately taken out or just by accident in #2586. If the former please close the PR.
It also adds the support for the format when seconds are missing, but the minute value is a float. 
I had to make changed to the `_AngleParser` class, but left the PLY generated stuff in `angle_parsetab.py` untouched as everything seemed to be working.

The use case motivation behind this was querying a region for objects in Simbad. It give back a list with the coordinates space separated, and sometimes with less than 6 values.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable-dev-piotr.firebaseapp.com/reviews/pkaminski/sample/5)

<!-- Reviewable:end -->
